### PR TITLE
Check for the existence of `kano-draw` progress within the project tracking, before checking for specific group

### DIFF
--- a/src/elements/kw-view-projects/kw-view-projects.html
+++ b/src/elements/kw-view-projects/kw-view-projects.html
@@ -263,10 +263,11 @@
                     }
                     categories.forEach((category, catId) => {
                         if (category.api_progress_tracking.indexOf('make-art') !== -1) {
-                            let artGroup = profile.stats['kano-draw'].groups[category.api_progress_tracking.replace('make-art-', '')];
-                            if (artGroup) {
+                            let artGroups = profile.stats['kano-draw'].groups,
+                                currentArtGroup = artGroups ? artGroups[category.api_progress_tracking.replace('make-art-', '')] : null;
+                            if (currentArtGroup) {
                                 category.projects.forEach((project, projectId) => {
-                                    this.set(`categories.${catId}.projects.${projectId}.completed`, project.slug <= artGroup.challengeNo);
+                                    this.set(`categories.${catId}.projects.${projectId}.completed`, project.slug <= currentArtGroup.challengeNo);
                                 });
                             }
                         } else if (category.api_progress_tracking === 'make-apps') {


### PR DESCRIPTION
For users that have just signed up, or have no progress in Make Art, the `kano-draw` progress object is empty, so the app would throw an uncaught error  when trying to find sub-keys within the object. Uncaught errors were preventing the project listings from displaying.

Now the app checks for the `group` key before accessing sub-keys to avoid the error, and the project listings should not be interrupted.

This should fix this bug: https://trello.com/c/5x9uPif1/1185-new-users-who-complete-a-challenge-and-come-back-to-projects-have-missing-info