### PR TITLE
Set user null if no token

### DIFF
--- a/src/elements/kano-session/kano-session.html
+++ b/src/elements/kano-session/kano-session.html
@@ -84,6 +84,7 @@
                 }
                 if (!token) {
                     localStorage.removeItem('KW_TOKEN');
+                    this.set('user', null);
                 } else {
                     // Sets the legacy token
                     localStorage.setItem('KW_TOKEN', this.token);


### PR DESCRIPTION
If token is deleted elsewhere (e.g. Kano Code), make sure the user gets logged out in Kano World.