### PR TITLE
removed  /shares from KW2 which cause it call /shares from KW2

### DIFF
--- a/src/elements/kw-app/kw-app.html
+++ b/src/elements/kw-app/kw-app.html
@@ -227,12 +227,13 @@
                             on-signup="signup"
                             slot="right"
                             user="[[user]]"
-                            xp="[[user.profile.xp]]">
+                            xp="[[user.profile.xp]]"
+                            world-root="[[config.WORLD_URL]]">
                             </kano-user-menu>
         </kano-nav>
     </template>
     <script>
-        const catchUrls = [/^\/projects$/, /^\/welcome$/, /^\/start$/, /^\/shares/];
+        const catchUrls = [/^\/projects$/, /^\/welcome$/, /^\/start$/];
         Polymer({
             is: 'kw-app',
             behaviors: [


### PR DESCRIPTION
https://trello.com/c/2BiubTAn/1684-kano-code-when-moving-from-projects-to-shares-with-menu-bar-nothing-is-shown