### PR TITLE
Add properties for new kano-user-summary component

### DIFF
--- a/src/elements/kw-app/kw-app.html
+++ b/src/elements/kw-app/kw-app.html
@@ -228,7 +228,8 @@
                             slot="right"
                             user="[[user]]"
                             xp="[[user.profile.xp]]"
-                            world-root="[[config.WORLD_URL]]">
+                            world-root="[[config.WORLD_URL]]"
+                            user-summary="[[config.FEATURES.USER_SUMMARY]]">
                             </kano-user-menu>
         </kano-nav>
     </template>

--- a/src/js/config/development.html
+++ b/src/js/config/development.html
@@ -9,7 +9,10 @@
         Kano.World.config.WORLD_URL = 'http://localhost:7000';
         Kano.World.config.KANO_CODE_URL = 'http://localhost:4000';
         Kano.World.config.KANO_MAKEART_URL = 'https://localhost:3000';
-		Kano.World.config.KANO_ADVENTURES_URL = 'http://localhost:2000';
+        Kano.World.config.KANO_ADVENTURES_URL = 'http://localhost:2000';
+        Kano.World.config.FEATURES = {
+            USER_SUMMARY: true
+        };
 
     })(window.Kano = window.Kano || {});
 </script>

--- a/src/js/config/staging.html
+++ b/src/js/config/staging.html
@@ -9,7 +9,10 @@
         Kano.World.config.WORLD_URL = 'https://world-staging.kano.me';
         Kano.World.config.KANO_CODE_URL = 'https://apps-staging.kano.me';
         Kano.World.config.KANO_MAKEART_URL = 'https://art-staging.kano.me';
-		Kano.World.config.KANO_ADVENTURES_URL = 'http://adventures.kano.me';
+        Kano.World.config.KANO_ADVENTURES_URL = 'http://adventures.kano.me';
+        Kano.World.config.FEATURES = {
+            USER_SUMMARY: true
+        };
 
     })(window.Kano = window.Kano || {});
 </script>


### PR DESCRIPTION
* Add config options to turn on the new `kano-user-summary` in development and staging (but not production)
* Add `USER_SUMMARY` value to new `user-summary` property on the `kano-user-menu` component to activate this when applicable

Related changes to `kano-user-menu`: https://github.com/KanoComputing/kano-user-menu/pull/4

Trello card: https://trello.com/c/ezoWdvLU/1581-3-show-users-level-next-to-the-user-name-in-nav