### PR TITLE
Deleting local progress on logout

### DIFF
--- a/src/elements/kano-session/kano-session.html
+++ b/src/elements/kano-session/kano-session.html
@@ -129,6 +129,7 @@
                 });
             },
             logout () {
+                localStorage.setItem('progress', null);
                 this.set('user', null);
                 this.set('token', null);
                 promises = {};

--- a/src/elements/kw-app/kw-app.html
+++ b/src/elements/kw-app/kw-app.html
@@ -189,7 +189,7 @@
                    api-url="{{config.API_URL}}"
                    assets-path="/assets"
                    on-success="_authSuccess"
-                   on-skip="redirectToProjects"
+                   on-skip="_redirectToProjects"
                    on-cancel="_authCancelled"></kano-auth>
         <kw-blank-project-modal id="project-modal" opened="{{modalOpened}}" hidden$="[[!modalOpened]]"></kw-blank-project-modal>
         <div class="pages">
@@ -398,7 +398,7 @@
                     this.set('authCallbacks', null);
                 }
             },
-            redirectToProjects () {
+            _redirectToProjects () {
                 this.set('route.path', '/projects');
             }
         });


### PR DESCRIPTION
When a user has an account and logs out, the puzzle-challenges progress should not fall back to the local storage value, so we set it to null here.
In the longer term, it might make more sense to have this happening at logging in or creating an account while saving the localstorage progress with the account.. I think a feature ticket is on its way for that. Jonas ok'd this to be merged in before the current release.