### PR TITLE
Add site-root to kano-nav to link the logo through to the /projects page

### DIFF
--- a/src/elements/kw-app/kw-app.html
+++ b/src/elements/kw-app/kw-app.html
@@ -198,7 +198,8 @@
                 </template>
             </iron-lazy-pages>
         </div>
-        <kano-nav assets-path="/assets/navbar/">
+        <kano-nav assets-path="/assets/navbar/"
+                  site-root="/projects">
             <kano-primary-links assets-path="/assets/navbar/"
                                 current-site="[[config.WORLD_URL]]"
                                 selected-link="[[_computeSelectedLink(route.path)]]"


### PR DESCRIPTION
Trello card: https://trello.com/c/RiWjODJB/1748-kano-world-when-on-projects-and-clicking-on-the-kano-icon-you-are-sent-back-to-shares