### PR TITLE
Add follow button to the kw-share-detail card

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "marked-element": "PolymerElements/marked-element#^1.2.0",
     "prism-element": "PolymerElements/prism-highlighter#^1.2.0",
     "lazy-imports": "Polymer/lazy-imports#^0.0.2",
-    "web-components": "git@github.com:KanoComputing/web-components.git",
+    "web-components": "git@github.com:KanoComputing/web-components.git#master",
     "make-apps": "git@github.com:KanoComputing/make-apps.git"
   },
   "resolutions": {

--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -59,7 +59,7 @@
             }
             :host #share-container {
                 animation: fade-in 200ms linear;
-                background: var(--color-rhubarb);
+                background: var(--color-carnation);
             }
             :host #share-container,
             :host .share-content .loading,
@@ -107,7 +107,7 @@
                 padding-bottom: 10px;
             }
             :host .author {
-                color: var(--color-rhubarb);
+                color: var(--color-carnation);
             }
             :host .description {
                 margin: 0;
@@ -115,8 +115,8 @@
             }
             :host .social-nav {
                 @apply --layout-horizontal;
-                border-bottom: 1px solid var(--color-iron-grey);
-                color: var(--color-oslo-grey);
+                border-bottom: 1px solid var(--color-porcelain);
+                color: var(--color-grey);
                 list-style: none;
                 margin: 0;
                 padding: 0 0 20px 80px;
@@ -133,12 +133,12 @@
                 color: black;
             }
             :host .nav-item.active .nav-icon {
-                color: var(--color-sky-blue);
+                color: var(--color-sky);
             }
             :host .nav-item.active::after {
                 background-color: white;
-                border-left: 1px solid var(--color-iron-grey);
-                border-top: 1px solid var(--color-iron-grey);
+                border-left: 1px solid var(--color-porcelain);
+                border-top: 1px solid var(--color-porcelain);
                 bottom: -30px;
                 content: "";
                 height: 20px;
@@ -154,8 +154,8 @@
             }
             :host .supplementary-details {
                 @apply --layout-flex-4;
-                border-left: 1px solid var(--color-iron-grey);
-                color: var(--color-oslo-grey);
+                border-left: 1px solid var(--color-porcelain);
+                color: var(--color-grey);
                 padding: 0 20px 20px 20px;
             }
             :host .actions {
@@ -175,10 +175,10 @@
                 padding: 10px 0px;
             }
             :host .actions.above .action:last-child {
-                border-bottom: 1px solid var(--color-iron-grey);
+                border-bottom: 1px solid var(--color-porcelain);
             }
             :host .actions.above .action {
-                border-top: 1px solid var(--color-iron-grey);
+                border-top: 1px solid var(--color-porcelain);
             }
             :host .actions.above .action {
                 @apply --layout-horizontal;

--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -175,10 +175,10 @@
                 cursor: pointer;
                 padding: 10px 0px;
             }
-            :host .actions.above .action {
+            :host .actions.above .action:last-child {
                 border-bottom: 1px solid var(--color-iron-grey);
             }
-            :host .actions.above .action:first-child {
+            :host .actions.above .action {
                 border-top: 1px solid var(--color-iron-grey);
             }
             :host .actions.above .action {
@@ -191,12 +191,16 @@
             :host .actions.below .action {
                 @apply --layout-vertical;
                 @apply --layout-center;
+                width: 33%;
             }
             :host .actions.below .action .action-label {
                 padding-top: 5px;
             }
             :host .like.liked {
-                color: var(--color-rhubarb);
+                color: var(--color-carnation);
+            }
+            :host .following {
+                color: var(--color-azure);
             }
             :host .metadata {
                 list-style: none;
@@ -278,17 +282,19 @@
                 </div>
                 <div class="supplementary-details">
                     <ul class="actions above">
-                        <li class$="[[_computeLikeClass(liked)]]" on-tap="_onLikeTapped">
-                            <kano-particle-burst number-particles="40"
-                                               gravity="0.5"
-                                               particle-decay="0.04"
-                                               max-particle-size="13">
-                                <iron-icon class="action-icon" icon="kano-icons:like"></iron-icon>
-                            </kano-particle-burst>
-                            <span class="action-label">
-                                Like
-                            </span>
-                        </li>
+                        <template is="dom-if" if="[[!sharedByUser]]">
+                          <li class$="[[_computeLikeClass(liked)]]" on-tap="_onLikeTapped">
+                              <kano-particle-burst number-particles="40"
+                                                 gravity="0.5"
+                                                 particle-decay="0.04"
+                                                 max-particle-size="13">
+                                  <iron-icon class="action-icon" icon="kano-icons:like"></iron-icon>
+                              </kano-particle-burst>
+                              <span class="action-label">
+                                  [[_computeLikeLabel(liked)]]
+                              </span>
+                          </li>
+                        </template>
                         <li class="action" on-tap="_onRemixTapped">
                             <iron-icon class="action-icon" icon="kano-icons:remix"></iron-icon>
                             <span class="action-label">
@@ -307,29 +313,33 @@
                         </template>
                     </ul>
                     <ul class="actions below">
-                        <li class$="[[_computeLikeClass(liked)]]" on-tap="_onLikeTapped">
-                            <kano-particle-burst number-particles="40"
-                                               gravity="0.5"
-                                               particle-decay="0.04"
-                                               max-particle-size="13">
-                                <iron-icon class="action-icon" icon="kano-icons:like"></iron-icon>
-                            </kano-particle-burst>
-                            <span class="action-label">
-                                Like
-                            </span>
-                        </li>
-                        <li class="action">
+                        <template is="dom-if" if="[[!sharedByUser]]">
+                            <li class$="[[_computeLikeClass(liked)]]" on-tap="_onLikeTapped">
+                                <kano-particle-burst number-particles="40"
+                                                   gravity="0.5"
+                                                   particle-decay="0.04"
+                                                   max-particle-size="13">
+                                    <iron-icon class="action-icon" icon="kano-icons:like"></iron-icon>
+                                </kano-particle-burst>
+                                <span class="action-label">
+                                    [[_computeLikeLabel(liked)]]
+                                </span>
+                            </li>
+                        </template>
+                        <li class="action" on-tap="_onRemixTapped">
                             <iron-icon class="action-icon" icon="kano-icons:remix"></iron-icon>
                             <span class="action-label">
                                 Remix
                             </span>
                         </li>
-                        <li class="action">
-                            <iron-icon class="action-icon" icon="kano-icons:share"></iron-icon>
-                            <span class="action-label">
-                                Share
-                            </span>
-                        </li>
+                        <template is="dom-if" if="[[!sharedByUser]]">
+                            <li class$="[[_computeFollowClass(following)]]" on-tap="_onFollowTapped">
+                                <iron-icon class="action-icon" icon="[[_computeFollowIcon(following)]]"></iron-icon>
+                                <span class="action-label">
+                                    [[_computeFollowLabel(following)]]
+                                </span>
+                            </li>
+                        </template>
                     </ul>
                 </div>
             </div>
@@ -363,6 +373,11 @@
                     type: String,
                     value: '../../assets/avatar/judoka-face.svg'
                 },
+                following: {
+                    type: Boolean,
+                    computed: '_computeFollowing(share, user.profile.following.*)',
+                    notify: true
+                },
                 liked: {
                     type: Boolean,
                     computed: '_computeLiked(share.likes.*)',
@@ -377,9 +392,13 @@
                     value: null,
                     notify: true
                 },
-                userId: {
-                    type: String,
-                    value: ''
+                sharedByUser: {
+                    type: Boolean,
+                    computed: '_sharedByUser(share, user)'
+                },
+                user: {
+                    type: Object,
+                    notify: true
                 }
             },
             observers: [
@@ -417,12 +436,31 @@
                 }
                 return this.defaultAvatar;
             },
+            _computeFollowing (share, following) {
+                if (!share || !following) {
+                    return false;
+                }
+                return following.base.some((userId) => {
+                    return userId === this.share.user.id;
+                });
+            },
+            _computeFollowClass (following) {
+                let baseClass = 'action',
+                    activeClass = following ? 'following' : 'follow';
+                return `${baseClass} ${activeClass}`;
+            },
+            _computeFollowIcon (following) {
+                return following ? 'kano-icons:followed' : 'kano-icons:follow';
+            },
+            _computeFollowLabel (following) {
+                return following ? 'Following' : 'Follow';
+            },
             _computeLiked (likes) {
-                if (!likes.base || !this.userId) {
+                if (!likes.base || !this.user) {
                     return false;
                 }
                 let userLike = likes.base.find((like) => {
-                    return like.user === this.userId;
+                    return like.user === this.user.id;
                 });
                 return userLike ? true : false;
             },
@@ -430,6 +468,9 @@
                 let baseClass = 'action like',
                     activeClass = liked ? 'liked' : 'not-liked';
                 return `${baseClass} ${activeClass}`;
+            },
+            _computeLikeLabel (liked) {
+                return liked ? 'Liked' : 'Like';
             },
             _computeNavItemClass (section, id) {
                 let baseClass = 'nav-item',
@@ -451,7 +492,18 @@
                 this.$['share-container'].appendChild(this.instance.root);
                 this.toggleClass('loaded', true);
             },
+            _onFollowTapped () {
+                if (this.sharedByUser) {
+                    return;
+                }
+                let id = this.share.user.id,
+                    action = this.following ? 'unfollow' : 'follow';
+                this.fire('follow-action', { action, id });
+            },
             _onLikeTapped (e) {
+                if (this.sharedByUser) {
+                    return;
+                }
                 if (!this.liked) {
                     let particleBursts = Polymer.dom(this.root).querySelectorAll('kano-particle-burst');
                     particleBursts.forEach((burst) => {
@@ -469,6 +521,12 @@
                 let item = this.share,
                     appType = item.app;
                 this.fire('remix-action', {id: item.id, type: appType});
+            },
+            _sharedByUser (share, user) {
+                if (!share || !user) {
+                    return false;
+                }
+                return share.user && share.user.id === user.id;
             },
             _shareChanged(share) {
                 let tagName, templateString, template;

--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -150,7 +150,6 @@
                 width: 20px;
             }
             :host kw-social-comment {
-                padding-top: 20px;
                 width: 100%;
             }
             :host .supplementary-details {
@@ -274,6 +273,7 @@
                                                    comments="[[share.comments]]"
                                                    page-number="[[share.pageNumber]]"
                                                    item-id="[[share.id]]"
+                                                   shared-by-user="[[sharedByUser]]"
                                                    tombstone$="[[!share]]">
                                                    </kw-social-comment>
                             </div>
@@ -389,7 +389,6 @@
                 },
                 share: {
                     type: Object,
-                    value: null,
                     notify: true
                 },
                 sharedByUser: {
@@ -404,29 +403,6 @@
             observers: [
                 '_shareChanged(share)'
             ],
-            getShareElement() {
-                return this;
-            },
-            _computeAction(appType) {
-                return false;
-                switch (appType) {
-                    case 'kano-draw':
-                    case 'make-apps':
-                    case 'make-adventures':
-                    case 'make-pong':
-                        return false;
-                        break;
-                    case 'make-music':
-                    case 'make-snake':
-                    case 'make-light':
-                    case 'make-minecraft':
-                        return true;
-                        break;
-                    default:
-                        return true;
-                        break;
-                }
-            },
             _computeAppLabel (app) {
                 return appLabels[app] || app;
             },

--- a/src/elements/kw-share-wrapper/kw-share-wrapper-behavior.html
+++ b/src/elements/kw-share-wrapper/kw-share-wrapper-behavior.html
@@ -8,7 +8,8 @@
             properties: {
                 selectedShare: {
                     type: Object,
-                    notify: true
+                    notify: true,
+                    observer: '_selectedShareChanged'
                 },
                 user: {
                     type: Object,
@@ -29,12 +30,16 @@
                         } else {
                             r.entries.forEach(item => {
                                 this.push('selectedShare.comments', item);
-                            })
+                            });
                         }
                     });
             },
             _getShareComments (id) {
-                return this.cacheOrAPI(this._getUrl('share-comments', { id })).then(res => res.entries);
+                return this.cacheOrAPI(`${this._getUrl('share-comments', {id})}?feature=true&page=0&limit=3`)
+                    .then(r => {
+                        this.set('selectedShare.pageNumber', r.next);
+                        this.set('selectedShare.comments', r.entries);
+                    });
             },
             _loadMoreData (e) {
                 let card = e.detail;
@@ -163,6 +168,11 @@
                         this.splice('selectedShare.likes', index, 1);
                     }
                 });
+            },
+            _selectedShareChanged (share) {
+                if (share) {
+                    this._getShareComments(share.id);
+                }
             }
         };
 

--- a/src/elements/kw-share-wrapper/kw-share-wrapper-behavior.html
+++ b/src/elements/kw-share-wrapper/kw-share-wrapper-behavior.html
@@ -9,6 +9,10 @@
                 selectedShare: {
                     type: Object,
                     notify: true
+                },
+                user: {
+                    type: Object,
+                    notify: true
                 }
             },
             _getMoreComments (id, page) {
@@ -38,6 +42,38 @@
                     return;
                 }
                 this._getMoreComments(card.id, card.page);
+            },
+            _onFollowAction (e) {
+                if (!this.user) {
+                    this.fire('login');
+                    return;
+                }
+                let follow = e.detail.action === 'follow',
+                    userId = e.detail.id,
+                    method = follow ? 'POST' : 'DELETE';
+                if (this.user.id !== userId) {
+                    if (follow) {
+                        this.push('user.profile.following', userId);
+                    } else {
+                        this._removeFollowee(userId);
+                    }
+                    let headers = new Headers({
+                        'Authorization': this.token,
+                        'Content-Type': 'application/json'
+                    });
+                    fetch(this._getUrl('follow', { userId }), {
+                        method,
+                        headers
+                    })
+                    .then((response) => response.json())
+                    .catch((err) => {
+                        if (follow) {
+                            this._removeFollowee(userId);
+                        } else {
+                            this.push('user.profile.following', userId);
+                        }
+                    })
+                }
             },
             _onLikeAction (e) {
                 if (!this.user) {
@@ -113,6 +149,13 @@
                     }).catch(error => {
                         this.set('selectedShare.comments.0.error', true);
                     });
+            },
+            _removeFollowee (id) {
+                this.user.profile.following.forEach((userId, index) => {
+                    if (userId === id) {
+                        this.splice('user.profile.following', index, 1);
+                    }
+                });
             },
             _removeSelectedLike () {
                 this.selectedShare.likes.forEach((like, index) => {

--- a/src/elements/kw-social-comment/kw-social-comment.html
+++ b/src/elements/kw-social-comment/kw-social-comment.html
@@ -267,25 +267,25 @@
                   seconds = Math.floor((new Date() - parsedDate) / 1000),
                   interval = Math.floor(seconds / 31536000);
               if (interval > 1) {
-                  return interval + " years";
+                  return interval + ' years';
               }
               interval = Math.floor(seconds / 2592000);
               if (interval > 1) {
-                  return interval + " months";
+                  return interval + ' months';
               }
               interval = Math.floor(seconds / 86400);
               if (interval > 1) {
-                  return interval + " days";
+                  return interval + ' days';
               }
               interval = Math.floor(seconds / 3600);
               if (interval > 1) {
-                  return interval + " hours";
+                  return interval + ' hours';
               }
               interval = Math.floor(seconds / 60);
               if (interval > 1) {
-                  return interval + " minutes";
+                  return interval + ' minutes';
               }
-              return Math.floor(seconds) + " seconds";
+              return Math.floor(seconds) + ' seconds';
           }
         });
     </script>

--- a/src/elements/kw-social-comment/kw-social-comment.html
+++ b/src/elements/kw-social-comment/kw-social-comment.html
@@ -2,13 +2,8 @@
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../../bower_components/iron-autogrow-textarea/iron-autogrow-textarea.html">
 <link rel="import" href="../../bower_components/iron-image/iron-image.html">
-<link rel="import" href="../../bower_components/date-util/date-util.html">
-<link rel="import" href="../../bower_components/web-components/kano-style/color.html">
-<link rel="import" href="../../bower_components/web-components/kano-style/button.html">
-<link rel="import" href="../../bower_components/web-components/kano-style/typography.html">
 <link rel="import" href="../../bower_components/web-components/kano-style/kano-style.html">
-<link rel="import" href="../../bower_components/iron-list/iron-list.html">
-<link rel="import" href="../../bower_components/web-components/kano-api-client-behavior/kano-api-client-behavior.html">
+
 <dom-module id="kw-social-comment">
     <template>
         <style>
@@ -33,12 +28,12 @@
                 line-height: 43px;
                 font-family: var(--font-body);
                 display: none;
-                margin: 0 0 20px 0;
+                margin: 20px 0;
             }
             .input-comment {
                 @apply --layout-horizontal;
                 @apply --layout-center;
-                margin-bottom: 20px;
+                margin: 20px 0;
                 width: 100%;
             }
             .comment-avatar {
@@ -88,9 +83,6 @@
                 border-bottom: 1px solid var(--color-iron-grey);
                 height: 100px;
                 width: 100%;
-            }
-            .comment:first-of-type {
-                border-top: 1px solid var(--color-iron-grey);
             }
             .comment.posting {
                 opacity: 0.6;
@@ -169,49 +161,44 @@
             :host([retry-button="hide"]) #retry {
                 display: none;
             }
-
         </style>
         <h3 shown$="[[!comments.length]]">Be the first to comment!</h3>
-        <div class="input-comment">
+        <div class="input-comment" hidden$="[[sharedByUser]]">
             <div class="comment-avatar">
                 <iron-image preload placeholder="../../assets/avatar/judoka-face.svg" fade sizing="contain"></iron-image>
             </div>
             <div class="comment-box">
                 <iron-autogrow-textarea id="comment"
-                                        placeholder="Leave a comment"
-                                        max-rows="7"></iron-autogrow-textarea>
+                placeholder="Leave a comment"
+                max-rows="7"></iron-autogrow-textarea>
                 <button class="orange-button comment-button" on-tap="_commentButtonTapped">
                     <span>comment</span>
                 </button>
             </div>
         </div>
-        <iron-list items="[[comments]]" as="comment" hidden$="[[comment]]">
-            <template>
-                <div class$="comment [[_computePostingClass(comment.posting)]]">
-                    <div class="comment-avatar">
-                        <iron-image preload placeholder="/assets/icons/shares/commentAvatar.svg" fade sizing="contain" src="{{comment.author.avatar.urls.circle}}"></iron-image>
-                    </div>
-                    <div class="content">
-                        <p><span class="author">{{comment.author.username}}</span>
-                          <span class="date">[[_timeSince(comment.date_created)]] ago</span>
-                        </p>
-                        <p><span inner-h-t-m-l="[[_lb(comment.text)]]"></span></p>
-                    </div>
-                    <button id="retry" on-tap="_retryButtonTapped" hidden$="[[!comment.error]]" class="error">retry</button>
+        <template is="dom-repeat" items="[[comments]]" as="comment">
+            <div class$="comment [[_computePostingClass(comment.posting)]]">
+                <div class="comment-avatar">
+                    <iron-image preload placeholder="/assets/icons/shares/commentAvatar.svg" fade sizing="contain" src="{{comment.author.avatar.urls.circle}}"></iron-image>
                 </div>
-            </template>
-        </iron-list>
-        <button hidden$="[[!comments.length]]" class="loader" id="loader" on-tap="_loadMoreData">Load more</button>
-
+                <div class="content">
+                    <p><span class="author">{{comment.author.username}}</span>
+                      <span class="date">[[_timeSince(comment.date_created)]] ago</span>
+                    </p>
+                    <p><span inner-h-t-m-l="[[_lb(comment.text)]]"></span></p>
+                </div>
+                <button id="retry" on-tap="_retryButtonTapped" hidden$="[[!comment.error]]" class="error">retry</button>
+            </div>
+        </template>
+        <button class="loader" id="loader" on-tap="_loadMoreData">Load more</button>
     </template>
     <script>
         Polymer({
             is: 'kw-social-comment',
-            behaviors: [Kano.APIClient],
             properties: {
                 comments: {
                     type: Array,
-                    value: null
+                    notify: true
                 },
                 itemId: {
                     type: String
@@ -228,6 +215,9 @@
                 retryButton: {
                     type: String,
                     reflectToAttribute: true
+                },
+                sharedByUser: {
+                    type: Boolean
                 }
             },
             _onDataLoad () {

--- a/src/elements/kw-view-feed/kw-view-feed.html
+++ b/src/elements/kw-view-feed/kw-view-feed.html
@@ -167,7 +167,8 @@
                 <div class="details">
                     <kw-share-detail share="[[selectedShare]]"
                                      tombstone$="[[!selectedShare]]"
-                                     user-id="[[user.id]]"
+                                     user="[[user]]"
+                                     on-follow-action="_onFollowAction"
                                      on-like-action="_onLikeAction"
                                      on-post-comment="_onPostComment"
                                      on-remix-action="_onRemixAction"


### PR DESCRIPTION
* Update `kw-share-detail` to take user object to allow for filtering of `following` users
* Add remix button and remix event in `kw-share-detail`
* Remove unusued `_computeAction` and `getShareElement` functions in `kw-share-detail`
* Hide like and follow buttons if the card belows to the current user
* Update `kw-share-wrapper` with `_onFollowAction` handler to update user following
* Minor updates for consistency and updating colors

Trello card: https://trello.com/c/FCXv3ZtL/160-1-feed6-add-follow-user-to-kca-share-card-modal

## Prevent user from commenting on their own share
* Add `shared-by-user` property to `kw-social-comment` to prevent commenting when the user 'owns' the share
* Update comments when the `selectedShare` is changed in the `kw-share-wrapper` comment, to fix issue with comments not loading
* Hide comment input box when user owns a share to prevent them from commenting on their own share
* Use a `dom-repeat` to fix issues with `iron-list` displaying comment – may need to be visited in future