### PR TITLE
Small change to align with fixes in web-components

### DIFF
--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -625,12 +625,7 @@
                         window.setTimeout(() => burst.triggerParticles(), 250);
                     })
                 }
-                this.fire('like-action', {
-                    app: this.share.app,
-                    id: this.share.id,
-                    liked: !this.liked,
-                    userId: this.share.user.id
-                });
+                this.fire('like-action', this.liked);
             },
             _onRemixTapped () {
                 let item = this.share,


### PR DESCRIPTION
Aligns with refactoring in this PR: https://github.com/KanoComputing/web-components/pull/131

Since the `kano-share-wrapper-behavior` handles liking directly and manages the share, the `kw-sahre-detail` no longer needs to send so much information.