### PR TITLE
Fire view-user event when username is tapped

### DIFF
--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -146,6 +146,7 @@
             }
             :host .author {
                 color: var(--color-carnation);
+                cursor: pointer;
                 font-weight: bold;
             }
             :host .description {
@@ -377,7 +378,7 @@
                         </div>
                         <div class="detail">
                             <h3 class="title">[[share.title]]</h3>
-                            <h4 class="attribution">by <a class="author">[[share.user.username]]</a></h4>
+                            <h4 class="attribution">by <a class="author" on-tap="_userTapped">[[share.user.username]]</a></h4>
                             <p class="description">[[share.description]]</p>
                         </div>
                     </div>
@@ -768,6 +769,9 @@
                     action,
                     app
                 });
+            },
+            _userTapped () {
+                this.fire('view-user', { id: this.share.user.id });
             }
         });
     })();

--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -128,11 +128,12 @@
                 background-color: var(--color-sky);
             }
             :host .avatar {
-                transform: translateZ(0);
                 background-color: var(--color-sky);
+                cursor: pointer;
+                height: 80px;
                 position: absolute;
                 top: 5px;
-                height: 80px;
+                transform: translateZ(0);
                 width: 40px;
             }
             :host .title {
@@ -374,7 +375,13 @@
                 <div class="main-details">
                     <div class="header">
                         <div class="avatar-wrapper">
-                            <iron-image class="avatar" src$="[[avatar]]" sizing="cover" preload fade></iron-image>
+                            <iron-image class="avatar"
+                                        src$="[[avatar]]"
+                                        sizing="cover"
+                                        preload
+                                        fade
+                                        on-tap="_userTapped">
+                                        </iron-image>
                         </div>
                         <div class="detail">
                             <h3 class="title">[[share.title]]</h3>

--- a/src/elements/kw-social-comment/kw-social-comment.html
+++ b/src/elements/kw-social-comment/kw-social-comment.html
@@ -44,9 +44,12 @@
             }
             .comment-avatar .avatar {
                 border-radius: 100%;
-                width: 100%;
                 height: auto;
                 margin-top: 5px;
+                width: 100%;
+            }
+            .comment .avatar {
+                cursor: pointer;
             }
             iron-image {
                 height: 32px;
@@ -111,6 +114,7 @@
             }
             .author {
                 color: var(--color-kano-orange);
+                cursor: pointer;
                 font-weight: bold;
                 margin-right: 5px;
             }
@@ -198,10 +202,10 @@
         <template is="dom-repeat" items="[[comments]]" as="comment">
             <div class$="comment [[_computePostingClass(comment.posting)]]">
                 <div class="comment-avatar">
-                    <img class="avatar" src="[[_computeAvatar(comment)]]"></img>
+                    <img class="avatar" src="[[_computeAvatar(comment)]]" on-tap="_userTapped" />
                 </div>
                 <div class="content">
-                    <p class="comment-header"><span class="author">{{comment.author.username}}</span>
+                    <p class="comment-header"><span class="author" on-tap="_userTapped">{{comment.author.username}}</span>
                       <span class="date">[[_timeSince(comment.date_created, comments.*)]] ago</span>
                     </p>
                     <p class="comment-body"><span inner-h-t-m-l="[[_lb(comment.text)]]"></span></p>
@@ -353,6 +357,11 @@
                   return interval + ' minutes';
               }
               return Math.floor(seconds) + ' seconds';
+          },
+          _userTapped (e) {
+              let index = e.model.index,
+                  author = this.comments[index].author;
+              this.fire('view-user', { id: author.id });
           }
         });
     </script>


### PR DESCRIPTION
Update styling to add cursor

Required for this PR: https://github.com/KanoComputing/kano2-app/pull/426

Trello card: https://trello.com/c/xUwb824d/716-1-clicking-usernames-in-expanded-share-card-should-go-to-user-profile