### PR TITLE
Add assetsPath property to kw-share-detail

### DIFF
--- a/src/elements/kw-share-detail/kw-share-detail.html
+++ b/src/elements/kw-share-detail/kw-share-detail.html
@@ -385,7 +385,7 @@
                 </div>
                 <div class="content">
                     <div class="featured" hidden$="[[!featured]]">
-                       <iron-image class="featured-icon" src="../../assets/icons/shares/featured.svg" sizing="contain" preload fade></iron-image>
+                       <iron-image class="featured-icon" src$="[[assetsPath]]/featured.svg" sizing="contain" preload fade></iron-image>
                     </div>
                     <div id="share-container"></div>
                 </div>
@@ -539,6 +539,10 @@
                 Kano.Behaviors.ShareWrapper
             ],
             properties: {
+                assetsPath: {
+                    type: String,
+                    value: '../../assets/icons/shares'
+                },
                 displayCode: {
                     type: Boolean,
                     value: false


### PR DESCRIPTION
Allows the parent component to specify the assets path, so that the component can display the icons inside other contexts. Fixes the issue with the icon not displayed inside the app.

Trello card: https://trello.com/c/oUV7svtV/1064-p2-mac-msk-prod-regression-missing-staff-picks-icons